### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build Astro Project
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ajustinjames/ajustinjames-v2/security/code-scanning/4](https://github.com/ajustinjames/ajustinjames-v2/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the workflow's operations (e.g., checking out the repository and reading files). This ensures that the `GITHUB_TOKEN` has only the minimal permissions required, adhering to the principle of least privilege.

The changes will be made at the top of the workflow file, immediately after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
