### PR TITLE
Migrate blog to Astro content collections (#75)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,19 @@
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
+
+const blog = defineCollection({
+  // [^_] excludes _template.md from the collection
+  loader: glob({ base: './src/content/blog', pattern: '**/[^_]*.md' }),
+  schema: z.object({
+    title: z.string(),
+    pubDate: z.coerce.date(),
+    description: z.string(),
+    author: z.string().default('Aaron James'),
+    image: z.object({ url: z.string(), alt: z.string() }).optional(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/2025/adblocking-guide.md
+++ b/src/content/blog/2025/adblocking-guide.md
@@ -1,5 +1,4 @@
 ---
-layout: ../../../layouts/MarkdownPostLayout.astro
 title: 'Adblocking Solutions'
 pubDate: 2025-04-30
 description: 'Tips and tricks I have learned for blocking advertisements and trackers on the internet.'

--- a/src/content/blog/2025/why-i-chose-astro.md
+++ b/src/content/blog/2025/why-i-chose-astro.md
@@ -1,5 +1,4 @@
 ---
-layout: ../../../layouts/MarkdownPostLayout.astro
 title: 'Why I Chose Astro'
 pubDate: 2025-04-01
 description: 'Describing why I built my new website using Astro.'

--- a/src/content/blog/_template.md
+++ b/src/content/blog/_template.md
@@ -1,5 +1,4 @@
 ---
-layout: ../../layouts/MarkdownPostLayout.astro
 title: ''
 pubDate: YYYY-MM-DD
 description: ''

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,9 +1,19 @@
 ---
 import Layout from './Layout.astro';
-const { frontmatter, rawContent } = Astro.props;
 
-const wordCount = rawContent().split(/\s+/).filter(Boolean).length;
-const readingTime = Math.max(1, Math.ceil(wordCount / 200));
+interface Props {
+  frontmatter: {
+    title: string;
+    pubDate: Date;
+    description: string;
+    author: string;
+    image?: { url: string; alt: string };
+    tags: string[];
+  };
+  readingTime: number;
+}
+
+const { frontmatter, readingTime } = Astro.props;
 
 const formattedDate = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
@@ -17,13 +27,13 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
   description={frontmatter.description}
   image={frontmatter.image?.url}
   type="article"
-  publishedDate={frontmatter.pubDate?.toString()}
+  publishedDate={frontmatter.pubDate.toISOString()}
 >
   <article class="max-w-3xl mx-auto p-8 rounded-lg shadow-md bg-cardLightBg dark:bg-cardDarkBg border border-borderLight dark:border-borderDark">
     <header class="mb-8">
       <h1 class="text-3xl font-bold mb-4">{frontmatter.title}</h1>
       <div class="flex flex-wrap gap-4 items-center text-lightTextSecondary dark:text-darkTextSecondary">
-        <time datetime={frontmatter.pubDate.toString()}>
+        <time datetime={frontmatter.pubDate.toISOString()}>
           {formattedDate}
         </time>
         <span>{readingTime} min read</span>
@@ -41,12 +51,14 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
       <p class="mt-4 text-lg italic">{frontmatter.description}</p>
     </header>
 
-    <img
-      src={frontmatter.image.url}
-      alt={frontmatter.image.alt}
-      loading="lazy"
-      class="w-full max-w-2xl mx-auto rounded-lg mb-8"
-    />
+    {frontmatter.image && (
+      <img
+        src={frontmatter.image.url}
+        alt={frontmatter.image.alt}
+        loading="lazy"
+        class="w-full max-w-2xl mx-auto rounded-lg mb-8"
+      />
+    )}
 
     <div class="prose prose-zinc dark:prose-invert max-w-none">
       <slot />

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,10 +1,13 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import BlogPostCard from '../components/blog/BlogPostCard.astro';
-const allPosts = Object.values(import.meta.glob('./posts/**/*.md', { eager: true }));
-const recentPosts = allPosts
-    .filter((post: any) => post.url && !post.url.includes('_template'))
-    .sort((a: any, b: any) => new Date(b.frontmatter.pubDate).getTime() - new Date(a.frontmatter.pubDate).getTime())
+import { getCollection } from 'astro:content';
+
+const posts = await getCollection('blog', ({ data }) =>
+  import.meta.env.PROD ? !data.draft : true
+);
+const recentPosts = posts
+    .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
     .slice(0, 4);
 ---
 
@@ -16,14 +19,14 @@ const recentPosts = allPosts
         </header>
 
         <ul class="grid gap-6 md:grid-cols-2">
-            {recentPosts.map((post: any) => (
+            {recentPosts.map((post) => (
                 <li>
                     <BlogPostCard
-                        url={post.url}
-                        title={post.frontmatter.title}
-                        description={post.frontmatter.description}
-                        pubDate={post.frontmatter.pubDate}
-                        tags={post.frontmatter.tags}
+                        url={`/posts/${post.id}`}
+                        title={post.data.title}
+                        description={post.data.description}
+                        pubDate={post.data.pubDate.toISOString()}
+                        tags={post.data.tags}
                     />
                 </li>
             ))}

--- a/src/pages/posts/[...id].astro
+++ b/src/pages/posts/[...id].astro
@@ -1,0 +1,20 @@
+---
+import { getCollection, render } from 'astro:content';
+import MarkdownPostLayout from '../../layouts/MarkdownPostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) =>
+    import.meta.env.PROD ? !data.draft : true
+  );
+  return posts.map((post) => ({ params: { id: post.id }, props: { post } }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const wordCount = post.body?.split(/\s+/).filter(Boolean).length ?? 0;
+const readingTime = Math.max(1, Math.ceil(wordCount / 200));
+---
+<MarkdownPostLayout frontmatter={post.data} readingTime={readingTime}>
+  <Content />
+</MarkdownPostLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,34 +1,22 @@
 import rss from "@astrojs/rss";
 import type { APIContext } from "astro";
+import { getCollection } from "astro:content";
 
 export async function GET(context: APIContext) {
-	const posts = Object.values(
-		import.meta.glob<{ frontmatter: { title: string; pubDate: string; description: string } }>(
-			"./posts/**/*.md",
-			{ eager: true }
-		)
-	).filter((post) => {
-		const url = (post as { url?: string }).url;
-		return url && !url.includes("_template");
-	});
-
-	return rss({
-		title: "Aaron James",
-		description: "Thoughts on software development, technology, gaming, and more.",
-		site: context.site ?? "https://ajustinjames.com",
-		items: posts
-			.sort((a, b) =>
-				new Date(b.frontmatter.pubDate).getTime() -
-				new Date(a.frontmatter.pubDate).getTime()
-			)
-			.map((post) => {
-				const url = (post as { url?: string }).url ?? "";
-				return {
-					title: post.frontmatter.title,
-					pubDate: new Date(post.frontmatter.pubDate),
-					description: post.frontmatter.description,
-					link: url,
-				};
-			}),
-	});
+  const posts = await getCollection("blog", ({ data }) =>
+    import.meta.env.PROD ? !data.draft : true
+  );
+  return rss({
+    title: "Aaron James",
+    description: "Thoughts on software development, technology, gaming, and more.",
+    site: context.site ?? "https://ajustinjames.com",
+    items: posts
+      .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
+      .map((post) => ({
+        title: post.data.title,
+        pubDate: post.data.pubDate,
+        description: post.data.description,
+        link: `/posts/${post.id}`,
+      })),
+  });
 }


### PR DESCRIPTION
Closes #75.

Migrates the blog from raw page-route markdown (`src/pages/posts/YYYY/*.md` + per-post `layout:` frontmatter + `import.meta.glob`) to a typed Astro 5 content collection with a Zod schema.

## Changes
- **`src/content.config.ts`** — `blog` collection via the `glob` loader. Zod schema validates frontmatter. `image` is **optional** and `tags` defaults to `[]`, so authoring is unchanged minus the `layout:` line.
- **Posts moved** to `src/content/blog/2025/`; template to `src/content/blog/_template.md` (kept out of the build via the `[^_]` glob). `layout:` lines removed.
- **`src/pages/posts/[...id].astro`** — dynamic rest route. The year stays in the entry `id`, so **existing URLs (`/posts/2025/<name>`) are preserved** — sitemap and RSS links don't change. Drafts are filtered in `PROD`.
- **`MarkdownPostLayout.astro`** — typed `Props`, reading time now computed from `post.body` and passed in (collections drop `rawContent()`), optional image guarded, `pubDate` is a `Date`.
- **`blog.astro` / `rss.xml.ts`** — use `getCollection('blog')`.

## URL preservation
`dist/posts/2025/why-i-chose-astro/` and `dist/posts/2025/adblocking-guide/` build identically; `dist/rss.xml` and `dist/blog/` confirmed present.

## Verification
| Command | Result |
|---|---|
| `npm run check` | 0 errors / 0 warnings |
| `npm run build` | 7 pages, success |
| `npm test` | pass |
| `npm run lint` | clean |

## Follow-ups unblocked
#76 (schema-validated test coverage), #77 (tag pages / prev-next), #78 (collection-relative `astro:assets` images), #79 (JSON-LD / BlogPosting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)