### PR TITLE
Fix HTML validity, SEO copy, and breadcrumb styling

### DIFF
--- a/src/components/blog/BlogPostCard.astro
+++ b/src/components/blog/BlogPostCard.astro
@@ -18,30 +18,30 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
 ---
 
 <div class="hl-card-shell hover-lift group relative">
-    <a href={url} class="block">
-        <time datetime={pubDate.toISOString()} class="text-sm text-lightTextSecondary dark:text-darkTextSecondary font-mono">
-            {formattedDate}
-        </time>
+    <time datetime={pubDate.toISOString()} class="text-sm text-lightTextSecondary dark:text-darkTextSecondary font-mono">
+        {formattedDate}
+    </time>
 
-        <h3 class="mt-2 text-xl font-semibold tracking-tight text-lightTextPrimary dark:text-darkTextPrimary group-hover:text-primary">
+    <h3 class="mt-2 text-xl font-semibold tracking-tight text-lightTextPrimary dark:text-darkTextPrimary group-hover:text-primary">
+        <a href={url} class="after:absolute after:inset-0">
             {title}
-        </h3>
+        </a>
+    </h3>
 
-        <p class="mt-3 text-lightTextSecondary dark:text-darkTextSecondary line-clamp-2">
-            {description}
-        </p>
+    <p class="mt-3 text-lightTextSecondary dark:text-darkTextSecondary line-clamp-2">
+        {description}
+    </p>
 
-        {tags && tags.length > 0 && (
-            <div class="mt-3">
-                <TagList tags={tags} />
-            </div>
-        )}
-
-        <div class="mt-4 flex items-center text-sm text-primary">
-            <span class="group-hover:underline">Read more</span>
-            <svg class="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-            </svg>
+    {tags && tags.length > 0 && (
+        <div class="relative z-10 mt-3">
+            <TagList tags={tags} />
         </div>
-    </a>
+    )}
+
+    <div class="mt-4 flex items-center text-sm text-primary">
+        <span class="group-hover:underline">Read more</span>
+        <svg class="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+        </svg>
+    </div>
 </div>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,0 +1,8 @@
+// Shared site copy so descriptions used in multiple places (page meta, RSS
+// feed, etc.) can't drift out of sync.
+
+export const homeDescription =
+	"Aaron James is a software engineer — this site collects his projects and blog.";
+
+export const blogDescription =
+	"Thoughts on software development, technology, gaming, and more.";

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,51 +30,51 @@ const personSchema = isHomePage
 	: null;
 ---
 
-<script>
-	import "@ajustinjames/hardline-components";
-</script>
-
-<script is:inline>
-	const getThemePreference = () => {
-		if (
-			typeof localStorage !== "undefined" &&
-			localStorage.getItem("theme")
-		) {
-			return localStorage.getItem("theme");
-		}
-		return window.matchMedia("(prefers-color-scheme: dark)").matches
-			? "dark"
-			: "light";
-	};
-
-	const applyTheme = (theme) => {
-		document.documentElement.setAttribute("data-theme", theme);
-		const toggle = document.getElementById("theme-toggle");
-		if (toggle) {
-			toggle.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
-		}
-	};
-
-	applyTheme(getThemePreference());
-
-	window.toggleTheme = () => {
-		const current = document.documentElement.getAttribute("data-theme");
-		const next = current === "dark" ? "light" : "dark";
-		applyTheme(next);
-		if (typeof localStorage !== "undefined") {
-			localStorage.setItem("theme", next);
-		}
-	};
-
-	document.addEventListener("astro:after-swap", () => {
-		applyTheme(getThemePreference());
-	});
-</script>
-
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<!-- Inline theme script stays first in <head>, before any paint, to avoid
+		     a dark-mode flash of unstyled content (FOUC). -->
+		<script is:inline>
+			const getThemePreference = () => {
+				if (
+					typeof localStorage !== "undefined" &&
+					localStorage.getItem("theme")
+				) {
+					return localStorage.getItem("theme");
+				}
+				return window.matchMedia("(prefers-color-scheme: dark)").matches
+					? "dark"
+					: "light";
+			};
+
+			const applyTheme = (theme) => {
+				document.documentElement.setAttribute("data-theme", theme);
+				const toggle = document.getElementById("theme-toggle");
+				if (toggle) {
+					toggle.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
+				}
+			};
+
+			applyTheme(getThemePreference());
+
+			window.toggleTheme = () => {
+				const current = document.documentElement.getAttribute("data-theme");
+				const next = current === "dark" ? "light" : "dark";
+				applyTheme(next);
+				if (typeof localStorage !== "undefined") {
+					localStorage.setItem("theme", next);
+				}
+			};
+
+			document.addEventListener("astro:after-swap", () => {
+				applyTheme(getThemePreference());
+			});
+		</script>
+		<script>
+			import "@ajustinjames/hardline-components";
+		</script>
 		<!-- `sizes="any"` is to fix Chrome bug -->
 		<link rel="icon" href="/favicon.ico" sizes="any" />
 		<link rel="icon" href="/icon.svg" type="image/svg+xml" />

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -3,6 +3,7 @@ import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import Layout from '../../layouts/Layout.astro';
 import BlogPostCard from '../../components/blog/BlogPostCard.astro';
 import { getCollection } from 'astro:content';
+import { blogDescription } from '../../data/site';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const allPosts = await getCollection('blog');
@@ -17,7 +18,7 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 const { page } = Astro.props as Props;
 ---
 
-<Layout title="Blog" description="Blog Homepage">
+<Layout title="Blog" description={blogDescription}>
     <div class="max-w-4xl mx-auto py-8">
         <header class="mb-12">
             <h1 class="text-3xl font-bold">Recent Posts</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,9 +4,10 @@ import Hero from "../components/portfolio/Hero.astro";
 import Skills from "../components/portfolio/Skills.astro";
 import Experience from "../components/portfolio/Experience.astro";
 import Contact from "../components/contact/Contact.astro";
+import { homeDescription } from "../data/site";
 ---
 
-<Layout title="Aaron James" description="Homepage">
+<Layout title="Aaron James" description={homeDescription}>
     <Hero />
     <Skills />
     <Experience />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,13 +1,14 @@
 import rss from "@astrojs/rss";
 import type { APIContext } from "astro";
 import { getCollection } from "astro:content";
+import { blogDescription } from "../data/site";
 
 export async function GET(context: APIContext) {
 	const posts = await getCollection("blog");
 
 	return rss({
 		title: "Aaron James",
-		description: "Thoughts on software development, technology, gaming, and more.",
+		description: blogDescription,
 		site: context.site ?? "https://ajustinjames.com",
 		items: posts
 			.sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -78,6 +78,28 @@
 		align-items: center;
 	}
 
+	/* <hl-breadcrumb>'s slotted <a>/<span> children fall to Tailwind's preflight
+	   (@layer base) resetting color and text-decoration on every anchor via the
+	   `a` selector — the same unlayered-vs-@layer-base cascade fight as
+	   <hl-btn>/<hl-input> above. Without this, breadcrumb links render as
+	   browser-default blue underlined text instead of the hardline look.
+	   Reproduce the intended technical styling here in @layer components. */
+	hl-breadcrumb a {
+		font-family: var(--hl-alias-font-technical, "JetBrains Mono", monospace);
+		font-size: 12px;
+		color: var(--hl-alias-text-main);
+		text-decoration: none;
+	}
+	hl-breadcrumb a:hover {
+		text-decoration: underline;
+		color: var(--hl-global-color-accent, #ff4f00);
+	}
+	hl-breadcrumb span {
+		font-family: var(--hl-alias-font-technical, "JetBrains Mono", monospace);
+		font-size: 12px;
+		color: var(--hl-alias-text-muted);
+	}
+
 	/* Hardline-style hover-lift effect: nudges the element up-left and adds a
 	   heavier shadow on hover, matching the hardline shadow scale. */
 	.hover-lift {


### PR DESCRIPTION
## #88 — Nested anchors in BlogPostCard
The card wrapped the whole thing in `<a href={url}>`, and `TagList` rendered its own `<a>` per tag inside it — invalid `<a>`-in-`<a>` HTML. Restructured so the title is the primary link with a stretched hit area (`after:absolute after:inset-0`), and the tags/read-more row sit as siblings (`relative z-10` on the tag wrapper) so they stay independently clickable above the stretched link.

## #89 — Scripts rendered before `<html>`
`Layout.astro` had the hardline-components module script and the inline theme script above the `<html>` element, so Astro emitted them before `<html>` in the built output. Moved both inside `<head>`, keeping the inline theme script first (before the module script) so dark-mode still applies before paint. `astro:after-swap` re-theming is unchanged.

## #90 — Placeholder meta copy
Replaced `description="Homepage"` / `description="Blog Homepage"` with real one-sentence descriptions. Extracted the blog tagline into a shared `blogDescription` constant in `src/data/site.ts`, used by both the blog index page and `rss.xml.ts` so they can't drift. Also added `initial-scale=1` to the viewport meta.

## #86 — Breadcrumb loses styling to Tailwind preflight
`<hl-breadcrumb>`'s slotted `<a>`/`<span>` children lost hardline's styling to Tailwind's unlayered `a` reset — the same cascade-layer fight already documented for `hl-btn`/`hl-input` in `global.css`. Added matching `hl-breadcrumb a` / `hl-breadcrumb span` rules in `@layer components`.

## Verification
- `npm run build` — dist/index.html starts `<!DOCTYPE html><html lang="en">` with no preceding script tag
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — clean
- `npm test` — 33/33 passing

Fixes #88
Fixes #89
Fixes #90
Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)