### PR TITLE
Nav restructure: 4-item header + mobile disclosure menu

### DIFF
--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -1,6 +1,18 @@
 ---
 import { Icon } from "astro-icon/components";
 import { socialLinks } from "../data/social-links";
+
+interface FooterLink {
+	href: string;
+	label: string;
+}
+
+const footerNavLinks: FooterLink[] = [
+	{ href: "/projects", label: "Projects" },
+	{ href: "/blog", label: "Blog" },
+	{ href: "/notes", label: "Notes" },
+	{ href: "/links", label: "Links" },
+];
 ---
 
 <footer class="mt-auto w-full border-t border-borderLight dark:border-borderDark" aria-label="Page footer">
@@ -9,6 +21,20 @@ import { socialLinks } from "../data/social-links";
 			<p class="text-sm text-lightTextSecondary dark:text-darkTextSecondary">
 				© {new Date().getFullYear()} Aaron James
 			</p>
+			<nav aria-label="Footer navigation">
+				<ul class="flex items-center gap-4">
+					{footerNavLinks.map((link) => (
+						<li>
+							<a
+								href={link.href}
+								class="font-mono text-xs uppercase tracking-wide hover:text-primary motion-safe:transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+							>
+								{link.label}
+							</a>
+						</li>
+					))}
+				</ul>
+			</nav>
 			<div class="flex items-center space-x-2">
 				{socialLinks.map((link) => (
 					<a

--- a/src/layouts/Header.astro
+++ b/src/layouts/Header.astro
@@ -2,8 +2,26 @@
 import { Icon } from "astro-icon/components";
 const currentPath = Astro.url.pathname;
 
+interface NavLink {
+	href: string;
+	label: string;
+}
+
+const navLinks: NavLink[] = [
+	{ href: "/projects", label: "Projects" },
+	{ href: "/blog", label: "Blog" },
+	{ href: "/notes", label: "Notes" },
+	{ href: "/links", label: "Links" },
+];
+
+const isCurrent = (href: string) =>
+	href === "/blog" ? currentPath.startsWith("/blog") : currentPath === href;
+
 const navLinkClass =
-	"font-mono text-sm tracking-wide uppercase hover:text-primary motion-safe:transition-colors aria-[current=page]:text-primary aria-[current=page]:underline aria-[current=page]:decoration-primary aria-[current=page]:decoration-2 aria-[current=page]:underline-offset-8";
+	"font-mono text-sm tracking-wide uppercase hover:text-primary motion-safe:transition-colors aria-[current=page]:text-primary aria-[current=page]:underline aria-[current=page]:decoration-primary aria-[current=page]:decoration-2 aria-[current=page]:underline-offset-8 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-4";
+
+const mobileNavLinkClass =
+	"block px-4 py-3 font-mono text-sm tracking-wide uppercase hover:text-primary motion-safe:transition-colors aria-[current=page]:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:-outline-offset-2";
 ---
 
 <header class="border-b border-borderLight dark:border-borderDark">
@@ -22,23 +40,18 @@ const navLinkClass =
 				ajustinjames
 			</a>
 			<div class="flex gap-6 items-center">
-				<ul class="flex gap-8 items-center">
-					<li class="flex items-center">
-						<a
-							href="/projects"
-							class={navLinkClass}
-							aria-current={currentPath === "/projects" ? "page" : undefined}
-							>Projects</a
-						>
-					</li>
-					<li class="flex items-center">
-						<a
-							href="/blog"
-							class={navLinkClass}
-							aria-current={currentPath.startsWith("/blog") ? "page" : undefined}
-							>Blog</a
-						>
-					</li>
+				<ul class="hidden sm:flex gap-8 items-center">
+					{navLinks.map((link) => (
+						<li class="flex items-center">
+							<a
+								href={link.href}
+								class={navLinkClass}
+								aria-current={isCurrent(link.href) ? "page" : undefined}
+							>
+								{link.label}
+							</a>
+						</li>
+					))}
 				</ul>
 				<div class="flex items-center">
 					<button
@@ -63,7 +76,41 @@ const navLinkClass =
 						/>
 					</button>
 				</div>
+				<details id="mobile-nav" class="relative sm:hidden">
+					<summary
+						class="flex h-8 w-8 items-center justify-center rounded-none border border-lightTextPrimary dark:border-darkTextPrimary font-mono text-xs uppercase tracking-wide cursor-pointer select-none list-none hover:text-primary hover:border-primary motion-safe:transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 [&::-webkit-details-marker]:hidden"
+						aria-label="Toggle navigation menu"
+					>
+						<span aria-hidden="true">MENU</span>
+					</summary>
+					<ul
+						class="hl-card-shell rounded-none absolute right-0 top-full mt-2 w-48 z-50 divide-y divide-borderLight dark:divide-borderDark"
+					>
+						{navLinks.map((link) => (
+							<li>
+								<a
+									href={link.href}
+									class={mobileNavLinkClass}
+									aria-current={isCurrent(link.href) ? "page" : undefined}
+								>
+									{link.label}
+								</a>
+							</li>
+						))}
+					</ul>
+				</details>
 			</div>
 		</nav>
 	</div>
 </header>
+
+<script>
+	// hardline disclosure menu: ClientRouter's default swap morphs the header
+	// across navigations, which can leave the mobile <details> stuck [open].
+	// Force it closed after every swap so the menu never persists.
+	document.addEventListener("astro:after-swap", () => {
+		document
+			.getElementById("mobile-nav")
+			?.removeAttribute("open");
+	});
+</script>


### PR DESCRIPTION
## What changed

- **Header**: desktop nav now has 4 items — Projects / Blog / Notes / Links — using the existing mono uppercase link style with `aria-current="page"` accent state. Notes links to `/notes`, Links links to `/links` (both land in a parallel PR; linking now is expected).
- **Mobile (< sm)**: replaced the flat row with a hardline disclosure menu — a square, 0-radius `MENU` button (`<summary>`) and a `<details>` dropdown panel styled with `hl-card-shell` (hard offset shadow via `var(--hl-alias-shadow-2)`) and hairline dividers (`divide-y`) between items. Zero-JS via native `<details>`/`<summary>` for keyboard/focus accessibility; a tiny inline script listens for `astro:after-swap` to force the menu closed after ClientRouter navigations (Astro's DOM-morph swap can otherwise leave `[open]` stuck on the persisted header).
- **Footer**: added a matching Projects / Blog / Notes / Links link row (mono, small) between the copyright line and social icons. No `/subscribe` link added — that page doesn't exist yet.

## Mobile decision rationale

Measured before choosing: at a 390px viewport, available content width after `px-4` padding is ~358px. Estimated width of the flat-row elements (wordmark ~156px + 4 mono links with `gap-8` ~281px + `gap-6` + theme toggle ~54px) comes to roughly 490px — well over budget and guaranteed to wrap/crowd. So the disclosure menu (the issue's primary shape) was implemented rather than the "keep flat row" alternative.

## Verification

- `npm run build` — pass
- `npm run check` — 0 errors, 0 warnings (1 pre-existing unrelated hint in `Section.astro`)
- `npm run lint` — pass
- `npm test` — 33/33 passing

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)