### PR TITLE
feat: post reading experience (TOC, reading progress, copy-code) + breadcrumb fix + dependency bumps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
         "@iconify-json/line-md": "^1.2.5",
         "@tailwindcss/typography": "^0.5.16",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
-        "@typescript-eslint/parser": "^8.58.0",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^10.1.0",
-        "eslint-plugin-astro": "^1.6.0",
+        "eslint-plugin-astro": "^2.0.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.3"
       }
@@ -1751,13 +1751,13 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
@@ -2353,16 +2353,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2375,6 +2375,136 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
@@ -3051,88 +3181,109 @@
       }
     },
     "node_modules/astro-eslint-parser": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-1.4.0.tgz",
-      "integrity": "sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-2.1.0.tgz",
+      "integrity": "sha512-poUfd66bOTY59rQajtusj/+i6kaBc4pKXkBa2XHYjwBZyhWThS1sdlgxLrnmo7NQqLUpvhmEtkOONUBs9WIp9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.0.0 || ^3.0.0",
-        "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0",
-        "@typescript-eslint/types": "^7.0.0 || ^8.0.0",
+        "@astrojs/compiler": "^4.0.0",
+        "@typescript-eslint/scope-manager": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "astrojs-compiler-sync": "^1.0.0",
         "debug": "^4.3.4",
-        "entities": "^7.0.0",
-        "eslint-scope": "^8.0.1",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.0.0",
-        "fast-glob": "^3.3.3",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.8"
+        "entities": "^8.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "semver": "^7.3.8",
+        "tinyglobby": "^0.2.17"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^22.22.3 || ^24.16.0 || >=26.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
       }
     },
+    "node_modules/astro-eslint-parser/node_modules/@astrojs/compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/astro-eslint-parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/astro-eslint-parser/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/astro-eslint-parser/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/astro-eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/astro-eslint-parser/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4292,52 +4443,60 @@
         }
       }
     },
-    "node_modules/eslint-compat-utils": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz",
-      "integrity": "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "eslint": ">=6.0.0"
-      }
-    },
     "node_modules/eslint-plugin-astro": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-1.6.0.tgz",
-      "integrity": "sha512-yGIbLHuj5MOUXa0s4sZ6cVhv6ehb+WLF80tsrGaxMk6VTUExruMzubQDzhOYt8fbR1c9vILCCRSCsKI7M1whig==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-2.0.0.tgz",
+      "integrity": "sha512-XtzPTfw3+Q6mRbA7vgkq1lmUX1yopBXH1tZBx2LMD7+ZTxV0GVJ34KF13K6JHUU+wPtRRJDj6SY3O0ZR9wz6mQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14",
-        "@typescript-eslint/types": "^7.7.1 || ^8",
-        "astro-eslint-parser": "^1.3.0",
-        "eslint-compat-utils": "^0.6.0",
-        "globals": "^16.0.0",
-        "postcss": "^8.4.14",
-        "postcss-selector-parser": "^7.0.0"
+        "@eslint-community/eslint-utils": "^4.5.1",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@typescript-eslint/types": "^8.61.0",
+        "astro-eslint-parser": "^2.0.0",
+        "espree": "^11.0.0",
+        "globals": "^17.0.0",
+        "postcss": "^8.5.3",
+        "postcss-selector-parser": "^7.1.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^22.22.3 || ^24.16.0 || >=26.3.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
-        "eslint": ">=8.57.0"
+        "@typescript-eslint/parser": ">=8.61.0",
+        "eslint": ">=10.0.0",
+        "eslint-plugin-jsx-a11y": ">=6.10.2"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/parser": {
+          "optional": true
+        },
+        "eslint-plugin-jsx-a11y": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-astro/node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/eslint-plugin-astro/node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8018,13 +8177,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "@iconify-json/line-md": "^1.2.5",
     "@tailwindcss/typography": "^0.5.16",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
-    "@typescript-eslint/parser": "^8.58.0",
+    "@typescript-eslint/parser": "^8.62.0",
     "eslint": "^10.1.0",
-    "eslint-plugin-astro": "^1.6.0",
+    "eslint-plugin-astro": "^2.0.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.3"
   }

--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,44 @@
+---
+export interface Crumb {
+  label: string;
+  /** Omit on the final crumb — it renders as the current page, not a link. */
+  href?: string;
+}
+
+interface Props {
+  crumbs: Crumb[];
+}
+
+const { crumbs } = Astro.props;
+---
+<!--
+  Plain markup rather than <hl-breadcrumb>: that component hides its slot and
+  re-renders the crumbs into its shadow DOM, lifting the <a>/<span> children
+  straight into the <ol> without wrapping them in <li>. Its own shadow styles
+  only target `li:not(.sep) a`, so the visible links never match and fall back
+  to browser-default blue underline — and <a> as a direct child of <ol> is
+  invalid markup besides. Same approach as .hl-card-shell in global.css.
+-->
+<nav aria-label="Breadcrumb">
+  <ol class="flex flex-wrap items-center gap-2 font-mono text-xs">
+    {crumbs.map((crumb, index) => (
+      <li class="flex items-center gap-2">
+        {index > 0 && (
+          <span aria-hidden="true" class="text-lightTextSecondary dark:text-darkTextSecondary">/</span>
+        )}
+        {crumb.href ? (
+          <a
+            href={crumb.href}
+            class="no-underline text-lightTextPrimary dark:text-darkTextPrimary hover:text-primary hover:underline"
+          >
+            {crumb.label}
+          </a>
+        ) : (
+          <span aria-current="page" class="text-lightTextSecondary dark:text-darkTextSecondary">
+            {crumb.label}
+          </span>
+        )}
+      </li>
+    ))}
+  </ol>
+</nav>

--- a/src/components/blog/CopyCodeButtons.astro
+++ b/src/components/blog/CopyCodeButtons.astro
@@ -1,0 +1,92 @@
+---
+interface Props {
+  /** Selector for the container whose `<pre>` blocks get a copy button. */
+  target: string;
+}
+
+const { target } = Astro.props;
+---
+<div hidden data-copy-code data-copy-code-target={target}></div>
+
+<script>
+  const IDLE_LABEL = 'Copy';
+  const DONE_LABEL = 'Copied';
+  const FAILED_LABEL = 'Failed';
+  const RESET_DELAY_MS = 2000;
+
+  async function copyText(text: string): Promise<boolean> {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function addCopyButton(pre: HTMLPreElement, index: number) {
+    if (pre.dataset.copyReady) return;
+    pre.dataset.copyReady = 'true';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'relative';
+    pre.replaceWith(wrapper);
+    wrapper.append(pre);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.id = `copy-code-${index}`;
+    button.textContent = IDLE_LABEL;
+    // The visible label doubles as the state readout, so announce changes.
+    button.setAttribute('aria-live', 'polite');
+
+    const host = document.createElement('hl-btn');
+    host.setAttribute('size', 'sm');
+    // Code blocks render on a dark surface in both themes, so use the accent
+    // variant — its colours are theme-stable and stay legible on that surface.
+    host.setAttribute('variant', 'primary');
+    // Kept visible rather than hover-only so the button is discoverable on
+    // touch devices, dimmed so it stays out of the way while reading.
+    host.className = 'absolute right-2 top-2 opacity-70 hover:opacity-100 focus-within:opacity-100';
+    host.append(button);
+
+    const tooltip = document.createElement('hl-tooltip');
+    tooltip.setAttribute('for', button.id);
+    tooltip.setAttribute('placement', 'left');
+    tooltip.textContent = 'Copy to clipboard';
+
+    wrapper.append(host, tooltip);
+
+    let resetTimer = 0;
+
+    button.addEventListener('click', async () => {
+      const code = pre.querySelector('code');
+      const text = (code ?? pre).textContent ?? '';
+      const copied = await copyText(text);
+
+      button.textContent = copied ? DONE_LABEL : FAILED_LABEL;
+      window.clearTimeout(resetTimer);
+      resetTimer = window.setTimeout(() => {
+        button.textContent = IDLE_LABEL;
+      }, RESET_DELAY_MS);
+    });
+  }
+
+  function initCopyCode() {
+    const config = document.querySelector<HTMLElement>('[data-copy-code]');
+    const selector = config?.dataset.copyCodeTarget;
+    if (!selector) return;
+
+    // The Clipboard API needs a secure context; without it the button would
+    // always fail, so leave the code blocks untouched.
+    if (!navigator.clipboard) return;
+
+    const container = document.querySelector(selector);
+    if (!container) return;
+
+    container
+      .querySelectorAll<HTMLPreElement>('pre')
+      .forEach((pre, index) => addCopyButton(pre, index));
+  }
+
+  document.addEventListener('astro:page-load', initCopyCode);
+</script>

--- a/src/components/blog/ReadingProgress.astro
+++ b/src/components/blog/ReadingProgress.astro
@@ -6,10 +6,10 @@ interface Props {
 
 const { target } = Astro.props;
 
-// <hl-progress> is emitted via set:html for the same reason as <hl-breadcrumb>
-// elsewhere: @lit-labs/ssr chokes on slot-wrapping hardline elements during
-// static rendering. Tracked in #102 — revert to plain markup once fixed
-// upstream.
+// <hl-progress> is emitted via set:html because @lit-labs/ssr chokes on
+// slot-wrapping hardline elements during static rendering — the same crash
+// that .hl-card-shell works around for <hl-card> in global.css. Tracked in
+// #102; revert to plain markup once fixed upstream.
 const progressMarkup = '<hl-progress value="0" max="100"><progress value="0" max="100" aria-hidden="true"></progress></hl-progress>';
 ---
 <div

--- a/src/components/blog/ReadingProgress.astro
+++ b/src/components/blog/ReadingProgress.astro
@@ -1,0 +1,79 @@
+---
+interface Props {
+  /** Selector for the element whose scroll-through drives the bar. */
+  target: string;
+}
+
+const { target } = Astro.props;
+
+// <hl-progress> is emitted via set:html for the same reason as <hl-breadcrumb>
+// elsewhere: @lit-labs/ssr chokes on slot-wrapping hardline elements during
+// static rendering. Tracked in #102 — revert to plain markup once fixed
+// upstream.
+const progressMarkup = '<hl-progress value="0" max="100"><progress value="0" max="100" aria-hidden="true"></progress></hl-progress>';
+---
+<div
+  class="fixed inset-x-0 top-0 z-40 print:hidden"
+  data-reading-progress
+  data-reading-progress-target={target}
+  set:html={progressMarkup}
+/>
+
+<script>
+  // Drives the fixed top progress bar from the article's scroll position.
+  function initReadingProgress() {
+    const container = document.querySelector<HTMLElement>('[data-reading-progress]');
+    if (!container) return;
+
+    const selector = container.dataset.readingProgressTarget;
+    const article = selector ? document.querySelector<HTMLElement>(selector) : null;
+    const host = container.querySelector('hl-progress') as
+      | (HTMLElement & { value?: number })
+      | null;
+    const native = container.querySelector('progress');
+
+    if (!article || !host || !native) {
+      container.hidden = true;
+      return;
+    }
+
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+      const start = article.offsetTop;
+      const scrollable = article.offsetHeight - window.innerHeight;
+      const scrolled = window.scrollY - start;
+      const percent =
+        scrollable <= 0
+          ? 100
+          : Math.min(100, Math.max(0, (scrolled / scrollable) * 100));
+
+      native.value = percent;
+      // Keep the custom element's own state in sync so its next render does
+      // not reset the native <progress> back to zero.
+      host.value = percent;
+    };
+
+    const schedule = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule, { passive: true });
+
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        if (frame) cancelAnimationFrame(frame);
+        window.removeEventListener('scroll', schedule);
+        window.removeEventListener('resize', schedule);
+      },
+      { once: true },
+    );
+  }
+
+  document.addEventListener('astro:page-load', initReadingProgress);
+</script>

--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -1,0 +1,106 @@
+---
+import type { MarkdownHeading } from 'astro';
+import { buildToc } from '../../utils/toc';
+
+interface Props {
+  headings: MarkdownHeading[];
+}
+
+const { headings } = Astro.props;
+
+const entries = buildToc(headings);
+
+// Tailwind needs whole class names at build time, so the indent per level is
+// looked up rather than interpolated.
+const indentClass = ['pl-0', 'pl-4', 'pl-8'];
+---
+{entries.length > 0 && (
+  <nav aria-labelledby="toc-heading" class="hl-card-shell">
+    <h2
+      id="toc-heading"
+      class="font-mono text-xs font-semibold uppercase tracking-wider text-lightTextSecondary dark:text-darkTextSecondary"
+    >
+      On this page
+    </h2>
+    <ul class="mt-3 space-y-2 text-sm">
+      {entries.map((entry) => (
+        <li class={indentClass[entry.level] ?? 'pl-8'}>
+          <a
+            href={`#${entry.slug}`}
+            data-toc-link
+            class="block no-underline text-lightTextSecondary dark:text-darkTextSecondary hover:text-primary aria-[current=true]:text-primary aria-[current=true]:font-semibold"
+          >
+            {entry.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}
+
+<script>
+  // Highlights the table-of-contents entry for the heading currently in view.
+  // Runs on every page load so it survives ClientRouter navigations.
+  function initTocHighlight() {
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]'),
+    );
+    if (links.length === 0) return;
+
+    const byId = new Map(
+      links.map((link) => [decodeURIComponent(link.hash.slice(1)), link]),
+    );
+    const headings = Array.from(byId.keys())
+      .map((id) => document.getElementById(id))
+      .filter((heading): heading is HTMLElement => heading !== null);
+    if (headings.length === 0) return;
+
+    // Distance from the top of the viewport at which a heading counts as the
+    // one being read.
+    const ACTIVE_LINE_PX = 120;
+
+    let active: HTMLAnchorElement | null = null;
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+
+      // The last heading that has crossed the active line, falling back to the
+      // first heading while still above it.
+      let current = headings[0];
+      for (const heading of headings) {
+        if (heading.getBoundingClientRect().top > ACTIVE_LINE_PX) break;
+        current = heading;
+      }
+
+      const link = byId.get(current.id);
+      if (!link || link === active) return;
+      active?.removeAttribute('aria-current');
+      link.setAttribute('aria-current', 'true');
+      active = link;
+    };
+
+    const schedule = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule, { passive: true });
+
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        if (frame) cancelAnimationFrame(frame);
+        window.removeEventListener('scroll', schedule);
+        window.removeEventListener('resize', schedule);
+      },
+      { once: true },
+    );
+  }
+
+  // `astro:page-load` fires on the initial load too, so this covers both the
+  // first render and every ClientRouter navigation.
+  document.addEventListener('astro:page-load', initTocHighlight);
+</script>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from './Layout.astro';
 import TagList from '../components/blog/TagList.astro';
+import Breadcrumb from '../components/Breadcrumb.astro';
 import TableOfContents from '../components/blog/TableOfContents.astro';
 import ReadingProgress from '../components/blog/ReadingProgress.astro';
 import CopyCodeButtons from '../components/blog/CopyCodeButtons.astro';
@@ -42,7 +43,15 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
 >
   <ReadingProgress target="[data-post-article]" />
   <div class="max-w-3xl lg:max-w-6xl mx-auto py-8">
-    <div class="mb-4" set:html={`<hl-breadcrumb><a href="/">Home</a><a href="/blog">Blog</a><span>${frontmatter.title}</span></hl-breadcrumb>`} />
+    <div class="mb-4">
+      <Breadcrumb
+        crumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Blog', href: '/blog' },
+          { label: frontmatter.title },
+        ]}
+      />
+    </div>
     <!-- The aside comes first in source order so it stacks above the post on
          narrow screens; on lg+ it is placed into the second grid column. -->
     <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_16rem] lg:gap-8 lg:items-start">

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,8 +1,12 @@
 ---
 import Layout from './Layout.astro';
 import TagList from '../components/blog/TagList.astro';
+import TableOfContents from '../components/blog/TableOfContents.astro';
+import ReadingProgress from '../components/blog/ReadingProgress.astro';
+import CopyCodeButtons from '../components/blog/CopyCodeButtons.astro';
 import { readingTime } from '../utils/reading-time';
 import { Image } from 'astro:assets';
+import type { MarkdownHeading } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 
 interface PostLink {
@@ -13,11 +17,12 @@ interface PostLink {
 interface Props {
   frontmatter: CollectionEntry<'blog'>['data'];
   rawContent: () => string;
+  headings?: MarkdownHeading[];
   prevPost?: PostLink | null;
   nextPost?: PostLink | null;
 }
 
-const { frontmatter, rawContent, prevPost, nextPost } = Astro.props;
+const { frontmatter, rawContent, headings = [], prevPost, nextPost } = Astro.props;
 
 const estimatedReadingTime = readingTime(rawContent());
 
@@ -35,58 +40,69 @@ const formattedDate = new Intl.DateTimeFormat('en-US', {
   type="article"
   publishedDate={frontmatter.pubDate?.toString()}
 >
-  <div class="max-w-3xl mx-auto py-8">
+  <ReadingProgress target="[data-post-article]" />
+  <div class="max-w-3xl lg:max-w-6xl mx-auto py-8">
     <div class="mb-4" set:html={`<hl-breadcrumb><a href="/">Home</a><a href="/blog">Blog</a><span>${frontmatter.title}</span></hl-breadcrumb>`} />
-    <div class="hl-card-shell">
-      <article>
-        <header class="mb-8">
-          <h1 class="text-3xl font-bold mb-4">{frontmatter.title}</h1>
-          <div class="flex flex-wrap gap-4 items-center text-lightTextSecondary dark:text-darkTextSecondary">
-            <time datetime={frontmatter.pubDate.toString()}>
-              {formattedDate}
-            </time>
-            <span>{estimatedReadingTime} min read</span>
-            <p>Written by: {frontmatter.author}</p>
-          </div>
-          {frontmatter.tags?.length > 0 && (
-            <div class="mt-3">
-              <TagList tags={frontmatter.tags} />
+    <!-- The aside comes first in source order so it stacks above the post on
+         narrow screens; on lg+ it is placed into the second grid column. -->
+    <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_16rem] lg:gap-8 lg:items-start">
+      <aside class="mb-4 lg:mb-0 lg:col-start-2 lg:row-start-1 lg:sticky lg:top-8">
+        <TableOfContents headings={headings} />
+      </aside>
+      <div class="min-w-0 lg:col-start-1 lg:row-start-1">
+        <div class="hl-card-shell">
+          <article data-post-article>
+            <header class="mb-8">
+              <h1 class="text-3xl font-bold mb-4">{frontmatter.title}</h1>
+              <div class="flex flex-wrap gap-4 items-center text-lightTextSecondary dark:text-darkTextSecondary">
+                <time datetime={frontmatter.pubDate.toString()}>
+                  {formattedDate}
+                </time>
+                <span>{estimatedReadingTime} min read</span>
+                <p>Written by: {frontmatter.author}</p>
+              </div>
+              {frontmatter.tags?.length > 0 && (
+                <div class="mt-3">
+                  <TagList tags={frontmatter.tags} />
+                </div>
+              )}
+              <p class="mt-4 text-lg italic">{frontmatter.description}</p>
+            </header>
+
+            {frontmatter.image && (
+              <Image
+                src={frontmatter.image.src}
+                alt={frontmatter.image.alt}
+                widths={[400, 800, 1200]}
+                sizes="(max-width: 640px) 400px, (max-width: 1024px) 800px, 1200px"
+                class="w-full max-w-2xl mx-auto mb-8"
+              />
+            )}
+
+            <div class="prose prose-zinc dark:prose-invert max-w-none">
+              <slot />
             </div>
-          )}
-          <p class="mt-4 text-lg italic">{frontmatter.description}</p>
-        </header>
-
-        {frontmatter.image && (
-          <Image
-            src={frontmatter.image.src}
-            alt={frontmatter.image.alt}
-            widths={[400, 800, 1200]}
-            sizes="(max-width: 640px) 400px, (max-width: 1024px) 800px, 1200px"
-            class="w-full max-w-2xl mx-auto mb-8"
-          />
-        )}
-
-        <div class="prose prose-zinc dark:prose-invert max-w-none">
-          <slot />
+          </article>
         </div>
-      </article>
-    </div>
 
-    {(prevPost || nextPost) && (
-      <nav aria-label="Post navigation" class="mt-8 grid grid-cols-2 gap-4">
-        {prevPost ? (
-          <a href={`/posts/${prevPost.slug}`} class="hl-card-shell p-4 group hover-lift flex flex-col items-start no-underline">
-            <span class="text-sm text-lightTextSecondary dark:text-darkTextSecondary">&larr; Older</span>
-            <span class="mt-1 font-medium text-lightTextPrimary dark:text-darkTextPrimary group-hover:text-primary">{prevPost.title}</span>
-          </a>
-        ) : <div />}
-        {nextPost ? (
-          <a href={`/posts/${nextPost.slug}`} class="hl-card-shell p-4 group hover-lift flex flex-col items-end text-right no-underline">
-            <span class="text-sm text-lightTextSecondary dark:text-darkTextSecondary">Newer &rarr;</span>
-            <span class="mt-1 font-medium text-lightTextPrimary dark:text-darkTextPrimary group-hover:text-primary">{nextPost.title}</span>
-          </a>
-        ) : <div />}
-      </nav>
-    )}
+        {(prevPost || nextPost) && (
+          <nav aria-label="Post navigation" class="mt-8 grid grid-cols-2 gap-4">
+            {prevPost ? (
+              <a href={`/posts/${prevPost.slug}`} class="hl-card-shell p-4 group hover-lift flex flex-col items-start no-underline">
+                <span class="text-sm text-lightTextSecondary dark:text-darkTextSecondary">&larr; Older</span>
+                <span class="mt-1 font-medium text-lightTextPrimary dark:text-darkTextPrimary group-hover:text-primary">{prevPost.title}</span>
+              </a>
+            ) : <div />}
+            {nextPost ? (
+              <a href={`/posts/${nextPost.slug}`} class="hl-card-shell p-4 group hover-lift flex flex-col items-end text-right no-underline">
+                <span class="text-sm text-lightTextSecondary dark:text-darkTextSecondary">Newer &rarr;</span>
+                <span class="mt-1 font-medium text-lightTextPrimary dark:text-darkTextPrimary group-hover:text-primary">{nextPost.title}</span>
+              </a>
+            ) : <div />}
+          </nav>
+        )}
+      </div>
+    </div>
   </div>
+  <CopyCodeButtons target="[data-post-article] .prose" />
 </Layout>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -2,6 +2,7 @@
 import Layout from '../../../layouts/Layout.astro';
 import Section from '../../../components/Section.astro';
 import BlogPostCard from '../../../components/blog/BlogPostCard.astro';
+import Breadcrumb from '../../../components/Breadcrumb.astro';
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -43,7 +44,15 @@ const { displayTag, posts } = Astro.props;
     as="h1"
     width="narrow"
   >
-    <div slot="top" class="mb-4" set:html={`<hl-breadcrumb><a href="/">Home</a><a href="/blog">Blog</a><span>Tag: ${displayTag}</span></hl-breadcrumb>`} />
+    <div slot="top" class="mb-4">
+      <Breadcrumb
+        crumbs={[
+          { label: 'Home', href: '/' },
+          { label: 'Blog', href: '/blog' },
+          { label: `Tag: ${displayTag}` },
+        ]}
+      />
+    </div>
 
     <ul class="grid gap-6 md:grid-cols-2">
       {posts.map((post) => (

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -21,7 +21,7 @@ export async function getStaticPaths() {
 }
 
 const { post, prevPost, nextPost } = Astro.props;
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
 
 const siteUrl = "https://ajustinjames.com";
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
@@ -49,7 +49,7 @@ const blogPostingSchema = {
 };
 ---
 
-<MarkdownPostLayout frontmatter={post.data} rawContent={() => post.body ?? ''} prevPost={prevPost} nextPost={nextPost}>
+<MarkdownPostLayout frontmatter={post.data} rawContent={() => post.body ?? ''} headings={headings} prevPost={prevPost} nextPost={nextPost}>
   <script is:inline type="application/ld+json" set:html={JSON.stringify(blogPostingSchema)} />
   <Content />
 </MarkdownPostLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -78,28 +78,6 @@
 		align-items: center;
 	}
 
-	/* <hl-breadcrumb>'s slotted <a>/<span> children fall to Tailwind's preflight
-	   (@layer base) resetting color and text-decoration on every anchor via the
-	   `a` selector — the same unlayered-vs-@layer-base cascade fight as
-	   <hl-btn>/<hl-input> above. Without this, breadcrumb links render as
-	   browser-default blue underlined text instead of the hardline look.
-	   Reproduce the intended technical styling here in @layer components. */
-	hl-breadcrumb a {
-		font-family: var(--hl-alias-font-technical, "JetBrains Mono", monospace);
-		font-size: 12px;
-		color: var(--hl-alias-text-main);
-		text-decoration: none;
-	}
-	hl-breadcrumb a:hover {
-		text-decoration: underline;
-		color: var(--hl-global-color-accent, #ff4f00);
-	}
-	hl-breadcrumb span {
-		font-family: var(--hl-alias-font-technical, "JetBrains Mono", monospace);
-		font-size: 12px;
-		color: var(--hl-alias-text-muted);
-	}
-
 	/* <hl-progress> styles its slotted <progress> through ::slotted(), which
 	   cannot reach the ::-webkit-progress-value / ::-moz-progress-bar
 	   pseudo-elements that actually paint the fill — and Tailwind's preflight

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,6 +100,43 @@
 		color: var(--hl-alias-text-muted);
 	}
 
+	/* <hl-progress> styles its slotted <progress> through ::slotted(), which
+	   cannot reach the ::-webkit-progress-value / ::-moz-progress-bar
+	   pseudo-elements that actually paint the fill — and Tailwind's preflight
+	   (@layer base) beats the unlayered shadow rules for border/background, the
+	   same cascade fight described for <hl-btn> above. Reproduce the intended
+	   hardline bar here in @layer components. */
+	hl-progress > progress {
+		appearance: none;
+		-webkit-appearance: none;
+		display: block;
+		width: 100%;
+		height: 4px;
+		border: none;
+		background: var(--hl-alias-surface-bg-alt, #f0f0ec);
+		border-left: 4px solid var(--hl-alias-surface-border, #1a1a1a);
+	}
+	hl-progress > progress::-webkit-progress-bar {
+		background: var(--hl-alias-surface-bg-alt, #f0f0ec);
+	}
+	hl-progress > progress::-webkit-progress-value {
+		background: var(--hl-global-color-accent, #ff4f00);
+	}
+	hl-progress > progress::-moz-progress-bar {
+		background: var(--hl-global-color-accent, #ff4f00);
+	}
+	@media (prefers-reduced-motion: no-preference) {
+		hl-progress > progress::-webkit-progress-value {
+			transition: width 0.1s linear;
+		}
+	}
+
+	/* Keep headings clear of the fixed reading-progress bar when jumped to from
+	   the table of contents. */
+	.prose :is(h1, h2, h3, h4) {
+		scroll-margin-top: 2rem;
+	}
+
 	/* Hardline-style hover-lift effect: nudges the element up-left and adds a
 	   heavier shadow on hover, matching the hardline shadow scale. */
 	.hover-lift {

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -1,0 +1,47 @@
+import type { MarkdownHeading } from 'astro';
+
+/**
+ * A heading in the table of contents, with its depth normalised so that the
+ * shallowest heading present sits at level 0.
+ */
+export interface TocEntry {
+  slug: string;
+  text: string;
+  /** 0 for the shallowest heading level in the post, 1 for the next, and so on. */
+  level: number;
+}
+
+interface BuildTocOptions {
+  /**
+   * Shallowest heading depth to include. Defaults to 1: the post title is
+   * rendered by the layout rather than the Markdown body, so an `<h1>` in the
+   * body is a real section heading and some posts use it that way.
+   */
+  minDepth?: number;
+  /** Deepest heading depth to include. Defaults to 3. */
+  maxDepth?: number;
+}
+
+/**
+ * Turn Astro's `getHeadings()` output into a flat, indent-ready table of
+ * contents. Headings outside the depth range are dropped, and headings without
+ * a slug are skipped since they cannot be linked to.
+ */
+export function buildToc(
+  headings: MarkdownHeading[],
+  { minDepth = 1, maxDepth = 3 }: BuildTocOptions = {},
+): TocEntry[] {
+  const included = headings.filter(
+    (heading) => heading.depth >= minDepth && heading.depth <= maxDepth && Boolean(heading.slug),
+  );
+
+  if (included.length === 0) return [];
+
+  const shallowest = Math.min(...included.map((heading) => heading.depth));
+
+  return included.map((heading) => ({
+    slug: heading.slug,
+    text: heading.text,
+    level: heading.depth - shallowest,
+  }));
+}

--- a/test/toc.spec.ts
+++ b/test/toc.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { buildToc } from '../src/utils/toc';
+
+describe('buildToc()', () => {
+  it('returns an empty list when there are no headings', () => {
+    expect(buildToc([])).toEqual([]);
+  });
+
+  it('keeps h1/h2/h3 — the layout renders the post title, not the body', () => {
+    const toc = buildToc([
+      { depth: 1, slug: 'section', text: 'Section' },
+      { depth: 2, slug: 'intro', text: 'Intro' },
+      { depth: 3, slug: 'detail', text: 'Detail' },
+    ]);
+
+    expect(toc.map((entry) => entry.slug)).toEqual(['section', 'intro', 'detail']);
+    expect(toc.map((entry) => entry.level)).toEqual([0, 1, 2]);
+  });
+
+  it('drops headings deeper than h3', () => {
+    const toc = buildToc([
+      { depth: 2, slug: 'intro', text: 'Intro' },
+      { depth: 4, slug: 'aside', text: 'Aside' },
+    ]);
+
+    expect(toc.map((entry) => entry.slug)).toEqual(['intro']);
+  });
+
+  it('normalises levels relative to the shallowest heading present', () => {
+    const toc = buildToc([
+      { depth: 3, slug: 'a', text: 'A' },
+      { depth: 3, slug: 'b', text: 'B' },
+    ]);
+
+    expect(toc.map((entry) => entry.level)).toEqual([0, 0]);
+  });
+
+  it('indents deeper headings relative to the shallowest', () => {
+    const toc = buildToc([
+      { depth: 2, slug: 'a', text: 'A' },
+      { depth: 3, slug: 'a1', text: 'A1' },
+      { depth: 2, slug: 'b', text: 'B' },
+    ]);
+
+    expect(toc.map((entry) => entry.level)).toEqual([0, 1, 0]);
+  });
+
+  it('skips headings without a slug', () => {
+    const toc = buildToc([
+      { depth: 2, slug: '', text: 'Unlinkable' },
+      { depth: 2, slug: 'ok', text: 'OK' },
+    ]);
+
+    expect(toc.map((entry) => entry.slug)).toEqual(['ok']);
+  });
+
+  it('honours a custom depth range', () => {
+    const toc = buildToc(
+      [
+        { depth: 1, slug: 'title', text: 'Title' },
+        { depth: 2, slug: 'intro', text: 'Intro' },
+        { depth: 4, slug: 'deep', text: 'Deep' },
+      ],
+      { minDepth: 2, maxDepth: 4 },
+    );
+
+    expect(toc.map((entry) => entry.slug)).toEqual(['intro', 'deep']);
+    expect(toc.map((entry) => entry.level)).toEqual([0, 2]);
+  });
+
+  it('preserves heading text', () => {
+    const toc = buildToc([{ depth: 2, slug: 'why-astro', text: 'Why Astro?' }]);
+
+    expect(toc[0].text).toBe('Why Astro?');
+  });
+});


### PR DESCRIPTION
Closes #100. Also supersedes the four open Dependabot PRs (#82, #83, #84, #114).

## Post reading experience (#100)

Posts were bare rendered Markdown in a card. This turns them into a real reading surface.

**Table of contents** — built from `getHeadings()`, rendered as a hardline card with a mono uppercase label. Stacks above the post on narrow screens; sticky aside on `lg+`. The active section is tracked from scroll position (rAF-throttled) and highlighted in the accent colour via `aria-current`.

Depth filtering and level normalisation live in `src/utils/toc.ts` so they're unit-testable (8 new tests). `h1` is included: the layout renders the post title, not the Markdown body, so a body `h1` is a real section heading — and the adblocking guide uses them that way. Levels are normalised against the shallowest heading present, so posts that start at `h2` still render flush-left.

**Reading progress** — `<hl-progress>` fixed to the top of the viewport, driven by the article's scroll-through. The fill transition is gated behind `prefers-reduced-motion: no-preference`. The bar's fill colour is reproduced in `global.css` because `::slotted()` can't reach the `::-webkit-progress-value` / `::-moz-progress-bar` pseudo-elements the component targets — same class of workaround already documented there for `<hl-btn>` / `<hl-input>`.

**Copy-code buttons** — injected client-side onto each `<pre>` as `<hl-btn size="sm">` plus an `<hl-tooltip>`. Uses the accent (`primary`) variant since code blocks render on a dark surface in both themes, and its token values are theme-stable. Label flips to `Copied` / `Failed` for 2s. No-ops when the Clipboard API is unavailable (insecure context).

Rendering-only — no post prose was touched, per the AI content policy.

## Breadcrumb theming fix

Breadcrumb links rendered as browser-default blue/purple underlined text in both themes, badly out of place against the hardline look.

The cause turned out to be upstream rather than our CSS. `<hl-breadcrumb>` hides its slot (`display:none`) and re-renders the crumbs into its shadow DOM, lifting the light-DOM `<a>`/`<span>` children straight into the `<ol>` **without wrapping them in `<li>`**. Its shadow stylesheet only targets `li:not(.sep) a`, so the visible links never match and fall through to UA styles (`rgb(0,0,238)`, underlined). The `hl-breadcrumb a` rules in `global.css` were styling the *hidden* light-DOM copies the whole time — which is why the mono font appeared to apply but the colour never did. It's also invalid markup: `<ol>` may only contain `<li>`.

Replaced with a plain `<Breadcrumb>` component — the same approach `.hl-card-shell` already takes for `<hl-card>`: semantic `<nav>`/`<ol>`/`<li>`, `aria-current="page"` on the final crumb, styled with the Tailwind design tokens. Shared by the post layout and the tag pages, and it removes one more `set:html` workaround (#102).

## Dependency bumps

| Package | From | To | Dependabot PR |
|---|---|---|---|
| `actions/checkout` | 6 | 7 | #84 |
| `actions/setup-node` | 6 | 7 | #114 |
| `@typescript-eslint/parser` | 8.58.0 | 8.62.0 | #83 |
| `eslint-plugin-astro` | 1.6.0 | 2.0.0 | #82 |

`eslint-plugin-astro` v2 is a major: it requires ESLint v10 (already on `^10.1.0`) and Node `^22.22.3 || ^24.16.0 || >=26.3.0`. CI runs Node 22, so it satisfies the new floor. Lint passes clean with no config changes needed.

## Verification

`npm run check`, `npm run lint`, `npm test` (48 passing), and `npm run build` all green.

Driven through a real browser against `npm run preview` at 1440px and 390px, light and dark, plus a `prefers-reduced-motion` context. Confirmed: TOC renders and sticks, active-section highlight tracks scroll, progress reads 0 → 47 → 100 through the adblocking guide, copy button writes the right text to the clipboard and updates its label, and no console or page errors in any context.

Breadcrumbs re-checked after the fix on both the post and tag pages, both themes: `<ol>` now contains exactly three `<li>`, links are JetBrains Mono with no underline at `#1a1a1a` / `#f0f0ec`, and the current crumb is muted.

Code-block behaviour was checked against a temporary fixture post, since neither existing post contains a `<pre>`; that fixture is not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)