### PR TITLE
feat(projects): refresh project list, add status + live badges

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -45,5 +45,6 @@ export const projects: Project[] = [
 		technologies: ["Vite", "JavaScript", "pdf-lib", "CSS"],
 		status: "stable",
 		repoUrl: "https://github.com/ajustinjames/selling-insert-generator",
+		siteUrl: "https://sig.ajustinjames.com",
 	},
 ];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,22 +1,49 @@
+export type ProjectStatus = "active" | "stable";
+
 export interface Project {
 	name: string;
 	description: string;
 	technologies: string[];
+	/** `active` = under ongoing development, `stable` = shipped and holding steady. */
+	status: ProjectStatus;
 	repoUrl?: string;
 	siteUrl?: string;
+	/** Image from `src/assets/projects/`, imported so astro:assets can optimize it. */
+	screenshot?: ImageMetadata;
 }
 
 export const projects: Project[] = [
 	{
-		name: "Simple WoL",
-		description: "Wake-on-LAN web UI for remotely waking machines on a local network. Built with Go and vanilla JS.",
-		technologies: ["Go", "SQLite", "JavaScript"],
-		repoUrl: "https://github.com/ajustinjames/simple-wol",
+		name: "ajj-design",
+		description:
+			"Industrial-material design system platform. The current system, hardline, is framework-agnostic Lit web components fed by Style Dictionary tokens compiled from a single source of truth — 0px radii, hard-cast shadows, no gradients. It's what this site is built on.",
+		technologies: ["Lit", "TypeScript", "Style Dictionary", "Storybook"],
+		status: "active",
+		repoUrl: "https://github.com/ajustinjames/ajj-design",
+		siteUrl: "https://ajustinjames.github.io/ajj-design/",
+	},
+	{
+		name: "Aaron Intelligence",
+		description:
+			"Claude Code plugin marketplace hosting my own plugins — a shell-usage guard, a compressed-output mode, a cross-model delegation skill — plus a curated index of good third-party ones. Also ships launchers that discover every repo in a workspace and start a remote-control session per project.",
+		technologies: ["Claude Code", "Bash", "Markdown"],
+		status: "active",
+		repoUrl: "https://github.com/ajustinjames/aaron-intelligence",
+	},
+	{
+		name: "Decky Portal",
+		description:
+			"Decky Loader plugin that puts a web portal inside the Steam Deck's Quick Access Menu for streaming, browsing, and media playback without leaving a game. Forked from decky-pip and rebuilt around the quality-of-life features I kept wanting.",
+		technologies: ["TypeScript", "React", "Decky Loader", "Rollup"],
+		status: "active",
+		repoUrl: "https://github.com/ajustinjames/decky-portal",
 	},
 	{
 		name: "Selling Insert Generator",
-		description: "Client-side web app for generating thermal-printable 4×6 package insert PDFs for online seller storefronts. Fully configurable — runs entirely in the browser, no server required.",
+		description:
+			"Client-side web app for generating thermal-printable 4×6 package insert PDFs for online seller storefronts. Fully configurable — runs entirely in the browser, no server required.",
 		technologies: ["Vite", "JavaScript", "pdf-lib", "CSS"],
+		status: "stable",
 		repoUrl: "https://github.com/ajustinjames/selling-insert-generator",
 	},
 ];

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,8 +1,14 @@
 ---
+import { Image } from "astro:assets";
 import Layout from "../layouts/Layout.astro";
 import Section from "../components/Section.astro";
 import { projects } from "../data/projects";
 import TagList from "../components/blog/TagList.astro";
+
+const statusLabels = {
+	active: "Active",
+	stable: "Stable",
+} as const;
 ---
 
 <Layout title="Projects" description="A showcase of personal projects and side apps by Aaron James.">
@@ -10,9 +16,23 @@ import TagList from "../components/blog/TagList.astro";
 		<ul class="grid gap-6 md:grid-cols-2">
 			{projects.map((project) => (
 				<li class="hl-card-shell hover-lift">
-					<h2 class="text-xl font-semibold text-lightTextPrimary dark:text-darkTextPrimary">
-						{project.name}
-					</h2>
+					{project.screenshot && (
+						<Image
+							src={project.screenshot}
+							alt={`Screenshot of ${project.name}`}
+							widths={[400, 800]}
+							sizes="(min-width: 768px) 400px, 100vw"
+							class="mb-4 w-full border border-borderLight dark:border-borderDark"
+						/>
+					)}
+					<div class="flex items-baseline justify-between gap-3">
+						<h2 class="text-xl font-semibold text-lightTextPrimary dark:text-darkTextPrimary">
+							{project.name}
+						</h2>
+						<span class="shrink-0 font-mono text-xs uppercase tracking-wide text-lightTextSecondary dark:text-darkTextSecondary">
+							{statusLabels[project.status]}
+						</span>
+					</div>
 					<p class="mt-3 text-lightTextSecondary dark:text-darkTextSecondary">
 						{project.description}
 					</p>
@@ -20,11 +40,11 @@ import TagList from "../components/blog/TagList.astro";
 						<TagList tags={project.technologies} />
 					</div>
 					<div class="mt-4 flex gap-4 text-sm font-mono uppercase tracking-wide">
-						{project.repoUrl && (
-							<a href={project.repoUrl} target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">GitHub</a>
-						)}
 						{project.siteUrl && (
-							<a href={project.siteUrl} target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">Live Site</a>
+							<a href={project.siteUrl} target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">Live &#8599;</a>
+						)}
+						{project.repoUrl && (
+							<a href={project.repoUrl} target="_blank" rel="noopener noreferrer" class="text-lightTextSecondary hover:text-primary dark:text-darkTextSecondary">GitHub</a>
 						)}
 					</div>
 				</li>


### PR DESCRIPTION
## What

Refreshes `/projects` and picks up part of #110.

### Content
- **Removed Simple WoL** — the repo is archived and private, so the card pointed at a dead link.
- **Added three current projects:**
  - **ajj-design** — the hardline design system this site is built on. Links to the live Storybook.
  - **Aaron Intelligence** — Claude Code plugin marketplace + per-repo remote-control launchers.
  - **Decky Portal** — Decky Loader plugin putting a web portal in the Steam Deck Quick Access Menu.
- **Selling Insert Generator** now points at its deployment, `sig.ajustinjames.com`, so it picks up the live badge too.

Descriptions and tech tags were written from each repo's README and `package.json` rather than guessed.

### Card upgrades (partial #110)
- New `status` field (`"active" | "stable"`) rendered as a mono uppercase chip next to the project name.
- `siteUrl` promoted to the headline affordance — accent `LIVE ↗` badge — with the GitHub link demoted to secondary.
- Optional `screenshot?: ImageMetadata` field wired through `astro:assets` (`widths`/`sizes`, hairline border, 0px radius). Renders only when present, so images can be dropped into `src/assets/projects/` later without further code changes.

## Deliberately not done

- **No `archived` status.** #110 specced a muted ARCHIVED chip; on reflection a dead project should come off the page entirely — exactly what happened to Simple WoL here — rather than linger as a muted card. #110 stays open for the screenshot work.
- **No screenshot images.** The plumbing is in; the actual captures need to come from real running instances.
- **Link rows aren't bottom-aligned** within a grid row, so they sit at slightly different heights when two cards have different description lengths. Pre-existing behavior, not introduced here.

## Verification

- `npm run build` — passes, 13 pages built.
- `npx astro check` — 0 errors, 0 warnings.
- Rendered the built output in Chromium at 1280px and 390px, light and dark: all four cards resolve correct hrefs, no horizontal overflow, status chips clear the longest title, and every `dark:` token pair resolves.